### PR TITLE
KL - restoring Org table component, table page, and tests from botched merges

### DIFF
--- a/frontend/src/main/components/Organizations/OrganizationsTable.js
+++ b/frontend/src/main/components/Organizations/OrganizationsTable.js
@@ -1,22 +1,22 @@
-import OurTable, { _ButtonColumn} from "main/components/OurTable";
-// import { useBackendMutation } from "main/utils/useBackend";
-// import {  onDeleteSuccess } from "main/utils/UCSBDateUtils"
+import OurTable, { ButtonColumn} from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
+import {  onDeleteSuccess } from "main/utils/UCSBDateUtils"
 // import { useNavigate } from "react-router-dom";
-//import { hasRole } from "main/utils/currentUser";
+import { hasRole } from "main/utils/currentUser";
 
 
-// export function cellToAxiosParamsDelete(cell) {
-//     // return {
-//     //     url: "/api/UCSBOrganization",
-//     //     method: "DELETE",
-//     //     params: {
-//     //         orgCode: cell.row.values.orgCode
-//     //     }
-//     // }
-// }
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/UCSBOrganization",
+        method: "DELETE",
+        params: {
+            orgCode: cell.row.values.orgCode
+        }
+    }
+}
 
 
-export default function OrganizationsTable({ organizations, _currentUser }) {
+export default function OrganizationsTable({ organizations, currentUser }) {
 
     //const navigate = useNavigate();
 
@@ -25,15 +25,15 @@ export default function OrganizationsTable({ organizations, _currentUser }) {
     // }
 
     // Stryker disable all : hard to test for query caching
-    // const deleteMutation = useBackendMutation(
-    //     //cellToAxiosParamsDelete,
-    //     { onSuccess: onDeleteSuccess },
-    //     ["/api/UCSBOrganization/all"]
-    // );
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/UCSBOrganization/all"]
+    );
     // Stryker enable all 
 
     // Stryker disable next-line all : TODO try to make a good test for this
-   //const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+   const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
 
 
 
@@ -59,14 +59,13 @@ export default function OrganizationsTable({ organizations, _currentUser }) {
 
     const testid = "OrganizationsTable";
 
-    // const columnsIfAdmin = [
-    //     ...columns,
-    //     //ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable"),
-    //   //  ButtonColumn("Delete", "danger", deleteCallback, testid)
-    // ];
+    const columnsIfAdmin = [
+        ...columns,
+        //ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable"),
+        ButtonColumn("Delete", "danger", deleteCallback, testid)
+    ];
 
-    //const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
-    const columnsToDisplay = columns;
+    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
 
     return <OurTable
         data={organizations}

--- a/frontend/src/main/pages/Organizations/OrganizationsIndexPage.js
+++ b/frontend/src/main/pages/Organizations/OrganizationsIndexPage.js
@@ -1,28 +1,28 @@
 import React from 'react'
-//import { useBackend } from 'main/utils/useBackend'; // use prefix indicates a React Hook
+import { useBackend } from 'main/utils/useBackend'; // use prefix indicates a React Hook
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-// import OrganizationsTable from 'main/components/Organizations/OrganizationsTable';
-// import { useCurrentUser } from 'main/utils/currentUser' // use prefix indicates a React Hook
+import OrganizationsTable from 'main/components/Organizations/OrganizationsTable';
+import { useCurrentUser } from 'main/utils/currentUser' // use prefix indicates a React Hook
 
 export default function OrganizationsIndexPage() {
 
-//   const currentUser = useCurrentUser();
+  const currentUser = useCurrentUser();
 
-//   const { data: organizations, error: _error, status: _status } =
-//     useBackend(
-//       // Stryker disable next-line all : don't test internal caching of React Query
-//       ["/api/UCSBOrganization/all"],
-//             // Stryker disable next-line StringLiteral,ObjectLiteral : since "GET" is default, "" is an equivalent mutation
-//             { method: "GET", url: "/api/UCSBOrganization/all" },
-//       []
-//     );
+  const { data: organizations, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/UCSBOrganization/all"],
+            // Stryker disable next-line StringLiteral,ObjectLiteral : since "GET" is default, "" is an equivalent mutation
+            { method: "GET", url: "/api/UCSBOrganization/all" },
+      []
+    );
 
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>Organizations</h1>
-        <p>This is where the index page will go.</p> 
+        <OrganizationsTable organizations={organizations} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )


### PR DESCRIPTION
Merging PRs #64, #63, #61, and #54 was ineffectual for some reason, so this commit restores the most recent state of the repo from that series of commits.